### PR TITLE
Bump Microsoft.NETCore.UniversalWindowsPlatform

### DIFF
--- a/Sandbox/NUnitUwpTestCases/NUnitUwpTestCases.csproj
+++ b/Sandbox/NUnitUwpTestCases/NUnitUwpTestCases.csproj
@@ -119,7 +119,7 @@
       <Version>2.3.4</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>5.4.0</Version>
+      <Version>5.4.2</Version>
     </PackageReference>
     <PackageReference Include="NUnit">
       <Version>3.8.1</Version>


### PR DESCRIPTION
This commit was in dependabot/nuget/Sandbox/NUnitUwpTestCases/Microsoft.NETCore.UniversalWindowsPlatform-5.4.2

I see in master it's still 5.4.0: https://github.com/RandomEngy/UnitTestBoilerplateGenerator/blob/master/Sandbox/NUnitUwpTestCases/NUnitUwpTestCases.csproj#L122

So I guess this should be merged?

Maybe also drop the branch afterwards