### PR TITLE
Implement c# 9 record support

### DIFF
--- a/src/Services/TestGenerationService.cs
+++ b/src/Services/TestGenerationService.cs
@@ -15,8 +15,8 @@ using UnitTestBoilerplate.Utilities;
 namespace UnitTestBoilerplate.Services
 {
 	[Export(typeof(ITestGenerationService))]
-    public class TestGenerationService : ITestGenerationService
-    {
+	public class TestGenerationService : ITestGenerationService
+	{
 		private static readonly HashSet<string> PropertyInjectionAttributeNames = new HashSet<string>
 		{
 			"Microsoft.Practices.Unity.DependencyAttribute",
@@ -39,7 +39,7 @@ namespace UnitTestBoilerplate.Services
 
 		public async Task<string> GenerateUnitTestFileAsync(
 			ProjectItemSummary selectedFile,
-			EnvDTE.Project targetProject, 
+			EnvDTE.Project targetProject,
 			TestFramework testFramework,
 			MockFramework mockFramework)
 		{
@@ -144,8 +144,8 @@ namespace UnitTestBoilerplate.Services
 		}
 
 		private async Task<TestGenerationContext> CollectTestGenerationContextAsync(
-			ProjectItemSummary selectedFile, 
-			string targetProjectNamespace, 
+			ProjectItemSummary selectedFile,
+			string targetProjectNamespace,
 			TestFramework testFramework,
 			MockFramework mockFramework,
 			IBoilerplateSettings settings)
@@ -162,11 +162,15 @@ namespace UnitTestBoilerplate.Services
 			SyntaxNode root = await document.GetSyntaxRootAsync();
 			SemanticModel semanticModel = await document.GetSemanticModelAsync();
 
-			SyntaxNode firstClassDeclaration = root.DescendantNodes().FirstOrDefault(node => node.Kind() == SyntaxKind.ClassDeclaration || node.Kind() == SyntaxKind.StructDeclaration);
+			SyntaxNode firstClassDeclaration = root.DescendantNodes().FirstOrDefault(node =>
+			{
+				var kind = node.Kind();
+				return kind == SyntaxKind.ClassDeclaration || kind == SyntaxKind.StructDeclaration || kind == SyntaxKind.RecordDeclaration;
+			});
 
 			if (firstClassDeclaration == null)
 			{
-				throw new InvalidOperationException("Could not find class or struct declaration.");
+				throw new InvalidOperationException("Could not find class, struct or record declaration.");
 			}
 
 			if (firstClassDeclaration.ChildTokens().Any(node => node.Kind() == SyntaxKind.AbstractKeyword))
@@ -1068,8 +1072,8 @@ namespace UnitTestBoilerplate.Services
 		{
 			// Group them by TypeBaseName to see which ones need a more unique name
 			var results = from t in injectedTypes
-				group t by t.TypeBaseName into g
-				select new { TypeBaseName = g.Key, Types = g.ToList() };
+						  group t by t.TypeBaseName into g
+						  select new { TypeBaseName = g.Key, Types = g.ToList() };
 
 			foreach (var result in results)
 			{

--- a/src/UnitTestBoilerplate.csproj
+++ b/src/UnitTestBoilerplate.csproj
@@ -82,22 +82,25 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CommonServiceLocator" Version="2.0.3" />
-    <PackageReference Include="DiffPlex" Version="1.4.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis" Version="1.2.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="1.1.0" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="1.2.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="1.2.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="1.2.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="1.2.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="1.2.2" />
-    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="1.2.2" />
+    <PackageReference Include="DiffPlex" Version="1.7.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="3.10.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" Version="3.10.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.10.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="3.10.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="3.10.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Version="3.10.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.Common" Version="3.10.0" />
     <PackageReference Include="Microsoft.Composition" Version="1.0.31" />
     <PackageReference Include="Microsoft.NETCore.Platforms" Version="2.1.0" />
     <PackageReference Include="Microsoft.VisualStudio.ComponentModelHost">
       <Version>14.0.25424</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Imaging" Version="15.7.27703" />
-    <PackageReference Include="Microsoft.VisualStudio.LanguageServices" Version="1.2.2" />
+    <PackageReference Include="Microsoft.VisualStudio.LanguageServices" Version="3.10.0" />
     <PackageReference Include="Microsoft.VisualStudio.OLE.Interop" Version="7.10.6071" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.14.0" Version="14.3.25407" />
     <PackageReference Include="Microsoft.VisualStudio.Shell.Immutable.10.0" Version="10.0.30319" />
@@ -119,11 +122,11 @@
     <PackageReference Include="Microsoft.Win32.Primitives" Version="4.3.0" />
     <PackageReference Include="MvvmLightLibs" Version="5.4.1" />
     <PackageReference Include="NETStandard.Library" Version="2.0.3" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="System.AppContext" Version="4.3.0" />
     <PackageReference Include="System.Collections" Version="4.3.0" />
     <PackageReference Include="System.Collections.Concurrent" Version="4.3.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="1.1.37" />
+    <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
     <PackageReference Include="System.Console" Version="4.3.1" />
     <PackageReference Include="System.Diagnostics.Debug" Version="4.3.0" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.5.0" />

--- a/src/app.config
+++ b/src/app.config
@@ -50,6 +50,10 @@
         <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
         <bindingRedirect oldVersion="0.0.0.0-4.0.1.0" newVersion="4.0.1.0"/>
       </dependentAssembly>
+      <dependentAssembly>
+      <assemblyIdentity name="DiffPlex" publicKeyToken="1d35e91d1bd7bc0f" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.7.0.0" newVersion="1.7.0.0"/>
+      </dependentAssembly>
     </assemblyBinding>
   </runtime>
 </configuration>


### PR DESCRIPTION
Should fix #6 

- implement record support
- Update packages CodeAnalysis and diffplex
- Update Newtonsoft.json for build warning


**untested!** I cannot use `records` in the https://github.com/RandomEngy/UnitTestBoilerplateGenerator/blob/master/Sandbox/Classes/Classes.csproj project? 