### PR TITLE
New Tokens and Modifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Each mocking framework has its own pattern.
 
 ![Options Screenshot](OptionsScreenshot.png)
 
-[Supported format tokens documentation](https://github.com/Microsoft/UnitTestBoilerplateGenerator/wiki/Custom-Format-Tokens)
+[Supported format tokens documentation](https://github.com/RandomEngy/UnitTestBoilerplateGenerator/wiki/Custom-Format-Tokens)
 
 * Supports mocking generic interfaces
 * Automatically brings in appropriate using statements

--- a/src/Model/MethodDescriptor.cs
+++ b/src/Model/MethodDescriptor.cs
@@ -2,12 +2,13 @@
 {
 	public class MethodDescriptor
 	{
-		public MethodDescriptor(string name, MethodArgumentDescriptor[] methodParameters, bool isAsync, bool hasReturnType)
+		public MethodDescriptor(string name, MethodArgumentDescriptor[] methodParameters, bool isAsync, bool hasReturnType, string returnType)
 		{
 			Name = name;
 			MethodParameters = methodParameters;
 			IsAsync = isAsync;
 			HasReturnType = hasReturnType;
+			ReturnType = returnType;
 		}
 
 		public string Name { get; }
@@ -17,5 +18,7 @@
 		public bool IsAsync { get; }
 
 		public bool HasReturnType { get; }
+
+		public string ReturnType { get; }
 	}
 }

--- a/src/Model/MethodDescriptor.cs
+++ b/src/Model/MethodDescriptor.cs
@@ -2,13 +2,14 @@
 {
 	public class MethodDescriptor
 	{
-		public MethodDescriptor(string name, MethodArgumentDescriptor[] methodParameters, bool isAsync, bool hasReturnType, string returnType)
+		public MethodDescriptor(string name, MethodArgumentDescriptor[] methodParameters, bool isAsync, bool hasReturnType, string returnType, HttpType http)
 		{
 			Name = name;
 			MethodParameters = methodParameters;
 			IsAsync = isAsync;
 			HasReturnType = hasReturnType;
 			ReturnType = returnType;
+			Http = http;
 		}
 
 		public string Name { get; }
@@ -20,5 +21,19 @@
 		public bool HasReturnType { get; }
 
 		public string ReturnType { get; }
+
+		public HttpType Http { get; }
+	}
+
+	public enum HttpType
+	{
+		Get,
+		Post,
+		Put,
+		Patch,
+		Delete,
+		Options,
+		Head,
+		None
 	}
 }

--- a/src/Services/TestGenerationService.cs
+++ b/src/Services/TestGenerationService.cs
@@ -384,9 +384,9 @@ namespace UnitTestBoilerplate.Services
 
 		private static IEnumerable<AttributeSyntax> GetAttributeListNodes(SyntaxNode memberNode)
 		{
-			SyntaxNode parameterListNode = memberNode.ChildNodes().First(n => n.Kind() == SyntaxKind.AttributeList);
+			SyntaxNode parameterListNode = memberNode.ChildNodes().FirstOrDefault(n => n.Kind() == SyntaxKind.AttributeList);
 
-			return parameterListNode.ChildNodes().Where(n => n.Kind() == SyntaxKind.Attribute).Cast<AttributeSyntax>();
+			return parameterListNode == null ? new List<AttributeSyntax>() : parameterListNode?.ChildNodes().Where(n => n.Kind() == SyntaxKind.Attribute).Cast<AttributeSyntax>();
 		}
 
 		private async Task<TestGenerationContext> CollectTestGenerationContextAsync(ProjectItemSummary selectedFile, EnvDTE.Project targetProject, TestFramework testFramework, MockFramework mockFramework, IBoilerplateSettings settings)

--- a/src/Services/TestGenerationService.cs
+++ b/src/Services/TestGenerationService.cs
@@ -584,7 +584,6 @@ namespace UnitTestBoilerplate.Services
 					{
 						builder.Append("async");
 					}
-
 					break;
 
 				case "AsyncReturnType":
@@ -605,7 +604,6 @@ namespace UnitTestBoilerplate.Services
 							builder.AppendLine();
 						}
 					}
-
 					break;
 
 				case "MethodInvocationPrefix":
@@ -618,12 +616,10 @@ namespace UnitTestBoilerplate.Services
 					{
 						builder.Append("await ");
 					}
-
 					break;
 
 				case "MethodInvocation":
 					WriteMethodInvocation(builder, methodDescriptor, FindIndent(testTemplate, propertyIndex));
-
 					break;
 
 				default:

--- a/src/Services/TestGenerationService.cs
+++ b/src/Services/TestGenerationService.cs
@@ -736,42 +736,40 @@ namespace UnitTestBoilerplate.Services
 
 		private static void WriteMethodInvocation(StringBuilder builder, MethodDescriptor methodDescriptor, string currentIndent)
 		{
-			int numberOfParameters = methodDescriptor.MethodParameters.Count();
 			builder.Append($".{methodDescriptor.Name}(");
+			WriteMethodParameters(builder, methodDescriptor, currentIndent);
+			builder.Append(")");
+		}
 
+		private static void WriteMethodParameters(StringBuilder builder, MethodDescriptor methodDescriptor, string currentIndent)
+		{
+			int numberOfParameters = methodDescriptor.MethodParameters.Count();
 			if (numberOfParameters == 0)
 			{
-				builder.Append(")");
+				return;
 			}
-			else
+
+			builder.AppendLine();
+
+			for (int j = 0; j < numberOfParameters; j++)
 			{
-				builder.AppendLine();
+				builder.Append($"{currentIndent}	");
 
-				for (int j = 0; j < numberOfParameters; j++)
+				switch (methodDescriptor.MethodParameters[j].Modifier)
 				{
-					builder.Append($"{currentIndent}	");
+					case ParameterModifier.Out:
+						builder.Append("out ");
+						break;
+					case ParameterModifier.Ref:
+						builder.Append("ref ");
+						break;
+				}
 
-					switch (methodDescriptor.MethodParameters[j].Modifier)
-					{
-						case ParameterModifier.Out:
-							builder.Append("out ");
-							break;
-						case ParameterModifier.Ref:
-							builder.Append("ref ");
-							break;
-						default:
-							break;
-					}
-					builder.Append($"{methodDescriptor.MethodParameters[j].ArgumentName}");
+				builder.Append($"{methodDescriptor.MethodParameters[j].ArgumentName}");
 
-					if (j < numberOfParameters - 1)
-					{
-						builder.AppendLine(",");
-					}
-					else
-					{
-						builder.Append(")");
-					}
+				if (j < numberOfParameters - 1)
+				{
+					builder.AppendLine(",");
 				}
 			}
 		}

--- a/src/Services/TestGenerationService.cs
+++ b/src/Services/TestGenerationService.cs
@@ -17,6 +17,8 @@ namespace UnitTestBoilerplate.Services
 	[Export(typeof(ITestGenerationService))]
     public class TestGenerationService : ITestGenerationService
     {
+		#region Properties
+
 		private static readonly HashSet<string> PropertyInjectionAttributeNames = new HashSet<string>
 		{
 			"Microsoft.Practices.Unity.DependencyAttribute",
@@ -36,6 +38,10 @@ namespace UnitTestBoilerplate.Services
 
 		[Import]
 		internal IBoilerplateSettingsFactory SettingsFactory { get; set; }
+
+		#endregion Properties
+
+		#region Public Functions
 
 		public async Task<string> GenerateUnitTestFileAsync(
 			ProjectItemSummary selectedFile,
@@ -142,6 +148,10 @@ namespace UnitTestBoilerplate.Services
 
 			return relativePath;
 		}
+
+		#endregion Public Functions
+
+		#region Collect Tested Class Data
 
 		private async Task<TestGenerationContext> CollectTestGenerationContextAsync(
 			ProjectItemSummary selectedFile, 
@@ -394,6 +404,10 @@ namespace UnitTestBoilerplate.Services
 			string targetProjectNamespace = targetProject.Properties.Item("DefaultNamespace").Value as string;
 			return await this.CollectTestGenerationContextAsync(selectedFile, targetProjectNamespace, testFramework, mockFramework, settings);
 		}
+
+		#endregion Collect Tested Class Data
+
+		#region Generate Test Class
 
 		private string GenerateUnitTestContents(TestGenerationContext context)
 		{
@@ -1125,5 +1139,7 @@ namespace UnitTestBoilerplate.Services
 				}
 			}
 		}
+
+		#endregion Generate Test Class
 	}
 }

--- a/src/Services/TestGenerationService.cs
+++ b/src/Services/TestGenerationService.cs
@@ -243,7 +243,9 @@ namespace UnitTestBoilerplate.Services
 
 				var hasReturnType = !DoesReturnNonGenericTask(methodDeclaration) && !DoesReturnVoid(methodDeclaration);
 
-				methodDeclarations.Add(new MethodDescriptor(methodDeclaration.Identifier.Text, parameterTypes, isAsync, hasReturnType));
+				string returnType = methodDeclaration.ReturnType.ToFullString();
+
+				methodDeclarations.Add(new MethodDescriptor(methodDeclaration.Identifier.Text, parameterTypes, isAsync, hasReturnType, returnType));
 			}
 
 			string unitTestNamespace;
@@ -567,8 +569,12 @@ namespace UnitTestBoilerplate.Services
 			{
 				case "TestedMethodName":
 					builder.Append(methodDescriptor.Name);
-
 					break;
+
+				case "TestedMethodReturnType":
+					builder.Append(methodDescriptor.ReturnType);
+					break;
+
 				case "TestMethodName":
 					this.WriteTestMethodName(builder, context, methodDescriptor);
 					break;

--- a/src/Services/TestGenerationService.cs
+++ b/src/Services/TestGenerationService.cs
@@ -440,6 +440,10 @@ namespace UnitTestBoilerplate.Services
 		{
 			switch (tokenName)
 			{
+				case "":
+					builder.Append("$");
+					break;
+
 				case "Namespace":
 					builder.Append(context.UnitTestNamespace);
 					break;

--- a/src/Services/TestGenerationService.cs
+++ b/src/Services/TestGenerationService.cs
@@ -606,6 +606,10 @@ namespace UnitTestBoilerplate.Services
 					builder.Append(methodDescriptor.ReturnType);
 					break;
 
+				case "HttpType":
+					builder.Append(methodDescriptor.Http.ToString());
+					break;
+
 				case "TestMethodName":
 					this.WriteTestMethodName(builder, context, methodDescriptor);
 					break;

--- a/src/Services/TestGenerationService.cs
+++ b/src/Services/TestGenerationService.cs
@@ -671,6 +671,14 @@ namespace UnitTestBoilerplate.Services
 					WriteMethodInvocation(builder, methodDescriptor, FindIndent(testTemplate, propertyIndex));
 					break;
 
+				case "MethodParameters":
+					WriteMethodParameters(builder, methodDescriptor, FindIndent(testTemplate, propertyIndex));
+					break;
+
+				case "QueryParameters":
+					WriteQueryParameters(builder, methodDescriptor);
+					break;
+
 				default:
 					return false;
 			}
@@ -757,8 +765,10 @@ namespace UnitTestBoilerplate.Services
 
 		private static void WriteMethodParameters(StringBuilder builder, MethodDescriptor methodDescriptor, string currentIndent)
 		{
+			var httpTypes = new List<HttpType>() { HttpType.Post, HttpType.None };
+
 			int numberOfParameters = methodDescriptor.MethodParameters.Count();
-			if (numberOfParameters == 0)
+			if (numberOfParameters == 0 || !httpTypes.Contains(methodDescriptor.Http))
 			{
 				return;
 			}
@@ -785,6 +795,24 @@ namespace UnitTestBoilerplate.Services
 				{
 					builder.AppendLine(",");
 				}
+			}
+		}
+
+		private static void WriteQueryParameters(StringBuilder builder, MethodDescriptor methodDescriptor)
+		{
+			var httpTypes = new List<HttpType>() { HttpType.Post, HttpType.None };
+
+			int numberOfParameters = methodDescriptor.MethodParameters.Count();
+			if (numberOfParameters == 0 || httpTypes.Contains(methodDescriptor.Http))
+			{
+				return;
+			}
+
+			for (int j = 0; j < numberOfParameters; j++)
+			{
+				builder.Append(j==0 ? "?" : "&");
+				string argumentName = methodDescriptor.MethodParameters[j].ArgumentName;
+				builder.Append($"{argumentName}={{{argumentName}}}");
 			}
 		}
 

--- a/src/Utilities/StringUtilities.cs
+++ b/src/Utilities/StringUtilities.cs
@@ -74,7 +74,9 @@ namespace UnitTestBoilerplate.Utilities
 			}
 
 			string nextModifier;
+			string arg;
 			SplitToken(ref myModifier, out nextModifier);
+			SplitModifierArg(ref myModifier, out arg);
 
 			switch (myModifier)
 			{
@@ -83,6 +85,12 @@ namespace UnitTestBoilerplate.Utilities
 					break;
 				case "NewLineIfPopulated":
 					tokenValue = RunNewLineIfPopulatedReplacement(tokenValue);
+					break;
+				case "Remove":
+					tokenValue = RunRemoveReplacement(tokenValue, arg);
+					break;
+				case "LowerCase":
+					tokenValue = RunLowerCaseReplacement(tokenValue);
 					break;
 				default:
 					// Ignore the modifier
@@ -110,6 +118,20 @@ namespace UnitTestBoilerplate.Utilities
 			}
 		}
 
+		private static void SplitModifierArg(ref string modifier, out string arg)
+		{
+			int parenthesisIndex = modifier.IndexOf("(", StringComparison.Ordinal);
+			if (parenthesisIndex <= 0)
+			{
+				arg = string.Empty;
+			}
+			else
+			{
+				arg = modifier.Substring(parenthesisIndex + 1, modifier.Length - parenthesisIndex - 2);
+				modifier = modifier.Substring(0, parenthesisIndex);
+			}
+		}
+
 		#endregion Split Functions
 
 		#region Modifier Functions
@@ -128,6 +150,17 @@ namespace UnitTestBoilerplate.Utilities
 				tokenValueBuilder.AppendLine();
 			}
 			return tokenValueBuilder.ToString();
+		}
+
+		private static string RunRemoveReplacement(string tokenValue, string textToRemove)
+		{
+			return tokenValue.Replace(textToRemove, "");
+		}
+
+		private static string RunLowerCaseReplacement(string tokenValue)
+		{
+			tokenValue = tokenValue.ToLower();
+			return tokenValue;
 		}
 
 		#endregion Modifier Functions

--- a/src/Utilities/StringUtilities.cs
+++ b/src/Utilities/StringUtilities.cs
@@ -89,6 +89,9 @@ namespace UnitTestBoilerplate.Utilities
 				case "Remove":
 					tokenValue = RunRemoveReplacement(tokenValue, arg);
 					break;
+				case "RemoveGeneric":
+					tokenValue = RunRemoveGenericReplacement(tokenValue, arg);
+					break;
 				case "LowerCase":
 					tokenValue = RunLowerCaseReplacement(tokenValue);
 					break;
@@ -155,6 +158,45 @@ namespace UnitTestBoilerplate.Utilities
 		private static string RunRemoveReplacement(string tokenValue, string textToRemove)
 		{
 			return tokenValue.Replace(textToRemove, "");
+		}
+
+		private static string RunRemoveGenericReplacement(string tokenValue, string genericToRemove)
+		{
+			int genericStartPos;
+			if (string.IsNullOrEmpty(tokenValue) || (genericStartPos = tokenValue.IndexOf($"{genericToRemove}<", StringComparison.Ordinal)) < 0)
+			{
+				return tokenValue; //Generic isn't in this token
+			}
+
+			//Find appropriate closing bracket to remove
+			int genericMiddlePos = genericStartPos + genericToRemove.Length + 1;
+			int unpairedOpenArrows = 1;
+			int genericEndPos = -1;
+			for (int charInMiddle = genericMiddlePos; charInMiddle < tokenValue.Length; ++charInMiddle)
+			{
+				switch (tokenValue[charInMiddle])
+				{
+					case '<': ++unpairedOpenArrows; break;
+					case '>': --unpairedOpenArrows; break;
+				}
+				if (unpairedOpenArrows == 0)
+				{
+					genericEndPos = charInMiddle;
+					break;
+				}
+			}
+
+			if (genericEndPos == -1)
+			{
+				return tokenValue; //Unclosed Generic.  Can't remove.
+			}
+
+			var bufferWOutGeneric = new StringBuilder();
+			bufferWOutGeneric.Append(tokenValue.Substring(0, genericStartPos));
+			bufferWOutGeneric.Append(tokenValue.Substring(genericMiddlePos, genericEndPos - genericMiddlePos));
+			bufferWOutGeneric.Append(tokenValue.Substring(genericEndPos+1));
+
+			return bufferWOutGeneric.ToString();
 		}
 
 		private static string RunLowerCaseReplacement(string tokenValue)


### PR DESCRIPTION
@RandomEngy This can be a preliminary PR.  

Here's a few of the things that I have changed that were not stated in the original ticket:

- Added recursion to the modifier evaluation.  Now a single token can have multiple modifiers pinned onto it for a consolidated effect
- Refactored the TestedMethod call to be a wrapper around the writing of the Tested Method's parameters so that the parameters can be written alone.  While this doesn't quite fit the API calling model to a T, it does handle cases where a single object is handed to a Post request, which handles MOST of the Post cases in my own code.

Hopefully my comments in the commits will be sufficient to illustrate these and all of the other changes and additions I made to the code.

There are still things to do, but I'm going to need to create other issues and get approval for them, since I've reached the end of the week I named to my employer to get changes made.  The things I still see that need to be done include:

- Tweak the tokens a bit (or a lot) more to handle the edge cases in my SUT.
- Update the Wiki: I've gotten started [on my personal fork's wiki](https://github.com/jchesshir/UnitTestBoilerplateGenerator/wiki/Custom-Format-Tokens)
- Update the ticket to match the tokens that I ended up creating to get my personal template working as well as possible so far.  Certain data collection limitations caused me to think outside the box and come up with other ways to achieve my original intentions when I first wrote the ticket.
- Add Default Integration Test templates: I'm thinking that this would be much easier if I could wait until [Issue #1] (https://github.com/RandomEngy/UnitTestBoilerplateGenerator/issues/1) gets implemented.  As it is, I'm using the None Mock Framework section of your templates to store my integration tests.  This fits because Mocking isn't be utilized in my own mocking environment.  But it still doesn't seem to fit the best.  A separate category would be preferable, especially to store a default template.
- Add Unit Tests: I'm not sure the best way to go about this.  Your base project that the automated tests generate out of is not a Web Service library.  I started out creating a new project that was an ASP Web Service, but then realized that to use it as the basis for generating Web Service type tests would require a LOT of modifications to your original unit testing system.  Another way would be to add the dependencies to your original project.  Let me know what you think.

For testing, I just ended up coding to fit the template I've been manually working on for my own project and then switched over to run your unit tests whenever I did any refactoring to make sure I hadn't broken your legacy code.  Once we decide how to best set up the framework for adding tests of this nature to your project, I can add specific cases that represent the SUT I'm personally testing against to add to your repository.