### PR TITLE
Primary constructor support

### DIFF
--- a/Sandbox/Classes/Cases/PrimaryConstructorInjectedClassMultiple.cs
+++ b/Sandbox/Classes/Cases/PrimaryConstructorInjectedClassMultiple.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace UnitBoilerplate.Sandbox.Classes.Cases
+{
+	public class PrimaryConstructorInjectedClassMultiple(ISomeInterface someInterface, ISomeOtherInterface someOtherInterface)
+	{
+		private readonly ISomeInterface someInterface = someInterface;
+		private readonly ISomeOtherInterface someOtherInterface = someOtherInterface;
+	}
+}

--- a/Sandbox/Classes/Classes.csproj
+++ b/Sandbox/Classes/Classes.csproj
@@ -4,7 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
     <Nullable>enable</Nullable>
-	<LangVersion>10</LangVersion>
+	<LangVersion>12</LangVersion>
 	<RootNamespace>UnitBoilerplate.Sandbox.Classes</RootNamespace>
   </PropertyGroup>
 

--- a/src/Services/TestGenerationService.cs
+++ b/src/Services/TestGenerationService.cs
@@ -272,7 +272,7 @@ namespace UnitTestBoilerplate.Services
 			// Find constructor injection types
 			List<InjectableType> constructorInjectionTypes = new List<InjectableType>();
 
-			SyntaxNode constructorDeclaration = firstClassLikeDeclaration.ChildNodes().FirstOrDefault(n => n.Kind() == SyntaxKind.ConstructorDeclaration);
+			SyntaxNode constructorDeclaration = firstClassLikeDeclaration.ChildNodes().FirstOrDefault(n => n.Kind() == SyntaxKind.ConstructorDeclaration || n.Kind() == SyntaxKind.ParameterList);
 
 			if (constructorDeclaration != null)
 			{
@@ -409,7 +409,7 @@ namespace UnitTestBoilerplate.Services
 
 		private static IEnumerable<ParameterSyntax> GetParameterListNodes(SyntaxNode memberNode)
 		{
-			SyntaxNode parameterListNode = memberNode.ChildNodes().First(n => n.Kind() == SyntaxKind.ParameterList);
+			SyntaxNode parameterListNode = memberNode.Kind() != SyntaxKind.ParameterList ? memberNode.ChildNodes().First(n => n.Kind() == SyntaxKind.ParameterList) : memberNode;
 
 			return parameterListNode.ChildNodes().Where(n => n.Kind() == SyntaxKind.Parameter).Cast<ParameterSyntax>();
 		}


### PR DESCRIPTION
Support a new feature of Primary constructors from C# 12
https://learn.microsoft.com/en-us/dotnet/csharp/whats-new/csharp-12#primary-constructors

SyntaxKind.ParameterList already exists and is used. In case of Primary constructor this structure is not inside class constructor but rather on the class itself.

Added class to test new functionality.